### PR TITLE
Fix division-by-zero in schedule reporting

### DIFF
--- a/InstSch.py
+++ b/InstSch.py
@@ -352,7 +352,8 @@ class MultiDepartmentScheduler:
         
         print(f"Final results: {len(scheduled)} scheduled, {len(unscheduled)} unscheduled")
         print(f"Total hours scheduled: {total_hours_scheduled:.1f}")
-        print(f"Days needed: {days_needed} days ({total_hours_scheduled/daily_hours_target:.1f} theoretical days)")
+        theoretical_days = total_hours_scheduled / daily_hours_target if daily_hours_target > 0 else 0
+        print(f"Days needed: {days_needed} days ({theoretical_days:.1f} theoretical days)")
         
         return {
             'scheduled': scheduled,


### PR DESCRIPTION
## Summary
- handle zero daily hours when calculating theoretical days in InstSch schedule output

## Testing
- `python -m py_compile AMCBD.py AMCBDG.py AMCSummareyes.py InstSch.py SchEng.py`

------
https://chatgpt.com/codex/tasks/task_e_68420ab0830883289d4b60034e630c90